### PR TITLE
Fix new join tests on mimir

### DIFF
--- a/it/src/main/resources/tests/joins/fullOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/fullOuterEquiJoin.test
@@ -3,7 +3,6 @@
 
     "backends": {
         "couchbase": "skip",
-        "mimir": "pending",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
         "mongodb_read_only": "pending",

--- a/it/src/main/resources/tests/joins/leftOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/leftOuterEquiJoin.test
@@ -5,7 +5,7 @@
         "couchbase": "skip",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
-        "mimir": "pending",
+        "mimir": "ignoreFieldOrder",
         "mongodb_read_only": "pending",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",

--- a/it/src/main/resources/tests/joins/rightOuterEquiJoin.test
+++ b/it/src/main/resources/tests/joins/rightOuterEquiJoin.test
@@ -5,7 +5,7 @@
         "couchbase": "skip",
         "marklogic_json": "pending",
         "marklogic_xml": "pending",
-        "mimir": "pending",
+        "mimir": "ignoreFieldOrder",
         "mongodb_read_only": "pending",
         "mongodb_q_2_6": "pending",
         "mongodb_q_3_0": "pending",


### PR DESCRIPTION
The issue was in the tricky `transLeft`/`transRight` construction.  Basically, it was just all wrong.  It would have been wrong for inner joins as well (inner joins were actually being executed as full-outer joins!), but we don't have tests which reveal this flaw.  All fixed now.